### PR TITLE
feat: log discord user and IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+discord_oauth.json
+user_activity.log

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ A modern, all-in-one Windows optimization utility with a persistent, tabbed, dar
 5. To revert all optional tweaks, click **Revert Optional Tweaks** on the main screen.
 6. View logs at any time with the log window.
 
+## Logging user info
+
+To keep track of who runs the tool, RatzTweaks can log the Discord account and public IP of each user. To enable this, create a `discord_oauth.json` file alongside the script containing your Discord application's credentials:
+
+```json
+{
+  "client_id": "YOUR_CLIENT_ID",
+  "client_secret": "YOUR_CLIENT_SECRET",
+  "redirect_uri": "http://localhost:3000/callback"
+}
+```
+
+When the script starts, it opens a browser window asking the user to authorize with Discord. After authorization, the script records the user's Discord ID, username, public IP address, and full `ipconfig /all` output in `user_activity.log` for routing assistance. Each record is stored as a JSON object. Both `discord_oauth.json` and `user_activity.log` are ignored by Git.
+
 ## Optional Tweaks List
 
 - MSI Mode (enables MSI for all PCI devices)

--- a/RatzTweaks.ps1
+++ b/RatzTweaks.ps1
@@ -153,6 +153,58 @@ function Test-Admin {
         exit
     }
 }
+function Log-DiscordUser {
+    $config = Join-Path $PSScriptRoot 'discord_oauth.json'
+    if (-not (Test-Path $config)) { return }
+    try {
+        $cfg = Get-Content $config | ConvertFrom-Json
+        $clientId = $cfg.client_id
+        $clientSecret = $cfg.client_secret
+        $redirectUri = $cfg.redirect_uri
+        if (-not $redirectUri) { $redirectUri = 'http://localhost:3000/callback' }
+
+        $listener = New-Object System.Net.HttpListener
+        $listener.Prefixes.Add($redirectUri.TrimEnd('/') + '/')
+        $listener.Start()
+
+        $authUrl = "https://discord.com/api/oauth2/authorize?client_id=$clientId&redirect_uri=$([uri]::EscapeDataString($redirectUri))&response_type=code&scope=identify"
+        Start-Process $authUrl | Out-Null
+
+        $context = $listener.GetContext()
+        $code = $context.Request.QueryString['code']
+        $buffer = [System.Text.Encoding]::UTF8.GetBytes('Authorization complete. You may close this window.')
+        $context.Response.OutputStream.Write($buffer,0,$buffer.Length)
+        $context.Response.OutputStream.Close()
+        $listener.Stop()
+
+        $token = Invoke-RestMethod -Uri 'https://discord.com/api/oauth2/token' -Method Post -ContentType 'application/x-www-form-urlencoded' -Body @{
+            client_id    = $clientId
+            client_secret = $clientSecret
+            code          = $code
+            grant_type    = 'authorization_code'
+            redirect_uri  = $redirectUri
+        }
+        $user = Invoke-RestMethod -Uri 'https://discord.com/api/users/@me' -Headers @{ Authorization = "Bearer $($token.access_token)" }
+        $ip = (Invoke-RestMethod -Uri 'https://api.ipify.org').Trim()
+        $ipConfig = ''
+        try { $ipConfig = (ipconfig /all | Out-String) } catch {}
+
+        $logPath = Join-Path $PSScriptRoot 'user_activity.log'
+        $entry = [PSCustomObject]@{
+            timestamp  = Get-Date -Format o
+            id         = $user.id
+            username   = $user.username
+            public_ip  = $ip
+            ip_config  = $ipConfig
+        } | ConvertTo-Json -Compress
+        Add-Content -Path $logPath -Value $entry
+
+        Add-Log "Discord user: $($user.username) ($($user.id)) IP: $ip"
+    } catch {
+        Add-Log "ERROR in Log-DiscordUser: $($_.Exception.Message)"
+    }
+}
+
 
 
 # Helper: highlight active button (must be top-level)
@@ -1015,6 +1067,7 @@ $global:RatzLog = @()
 function Add-Log($msg) { $global:RatzLog += (Get-Date -Format 'HH:mm:ss') + '  ' + $msg }
 
 Test-Admin
+Log-DiscordUser
 Add-Log 'Started RatzTweaks.'
 Show-IntroUI
 Add-Log 'UI completed.'


### PR DESCRIPTION
## Summary
- log Discord username, ID, public IP, and `ipconfig` output via OAuth at startup
- document OAuth setup and ignore related files

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893dabb2d4c832cbfcecab23ed5714e