### PR TITLE
Unblock DRS cache and use lighter NVPI

### DIFF
--- a/RatzTweaks.ps1
+++ b/RatzTweaks.ps1
@@ -970,7 +970,14 @@ function Invoke-NVPI {
     param()
     # Start NVPI work in a background job so the UI thread is never blocked
     try {
-        $nvpiUrl = 'https://github.com/xHybred/NvidiaProfileInspectorRevamped/releases/download/v5.2/NVPI-Revamped.zip'
+        # Unblock NVIDIA DRS cache to avoid profile import issues
+        $drsPath = Join-Path $env:ProgramData 'NVIDIA Corporation\Drs'
+        if (Test-Path $drsPath) {
+            try {
+                Get-ChildItem -Path $drsPath -Recurse -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue
+            } catch {}
+        }
+        $nvpiUrl = 'https://github.com/Orbmu2k/nvidiaProfileInspector/releases/download/2.4.0.27/nvidiaProfileInspector.zip'
         $nipPath = Join-Path $PSScriptRoot 'RatzSettings.nip'
         $logPath = Join-Path $env:TEMP 'NVPI_job.log'
         $jobScript = {

--- a/ratzTweaksOld.ps1
+++ b/ratzTweaksOld.ps1
@@ -986,7 +986,14 @@ function Invoke-NVPI {
     param()
     # Start NVPI work in a background job so the UI thread is never blocked
     try {
-        $nvpiUrl = 'https://github.com/xHybred/NvidiaProfileInspectorRevamped/releases/download/v5.2/NVPI-Revamped.zip'
+        # Unblock NVIDIA DRS cache to avoid profile import issues
+        $drsPath = Join-Path $env:ProgramData 'NVIDIA Corporation\Drs'
+        if (Test-Path $drsPath) {
+            try {
+                Get-ChildItem -Path $drsPath -Recurse -ErrorAction SilentlyContinue | Unblock-File -ErrorAction SilentlyContinue
+            } catch {}
+        }
+        $nvpiUrl = 'https://github.com/Orbmu2k/nvidiaProfileInspector/releases/download/2.4.0.27/nvidiaProfileInspector.zip'
         $nipPath = Join-Path $PSScriptRoot 'RatzSettings.nip'
         $logPath = Join-Path $env:TEMP 'NVPI_job.log'
         $jobScript = {


### PR DESCRIPTION
## Summary
- unblock NVIDIA DRS cache before importing NVPI profiles
- switch NVPI download to official `Orbmu2k/nvidiaProfileInspector` release to avoid .NET 9 requirement

## Testing
- `pwsh -NoLogo -NoProfile -Command 'try { [ScriptBlock]::Create((Get-Content -Raw "RatzTweaks.ps1")) | Out-Null; "Parsed RatzTweaks.ps1" } catch { "RatzTweaks.ps1 parse error: $($_.Exception.Message)"; exit 1 }'`
- `pwsh -NoLogo -NoProfile -Command 'try { [ScriptBlock]::Create((Get-Content -Raw "ratzTweaksOld.ps1")) | Out-Null; "Parsed ratzTweaksOld.ps1" } catch { "ratzTweaksOld.ps1 parse error: $($_.Exception.Message)"; exit 1 }'`


------
https://chatgpt.com/codex/tasks/task_e_68a4c9771fac832c9fe69483b2d25b4f