### PR TITLE
Send Discord webhook during OAuth callback

### DIFF
--- a/discord_webhook.secret
+++ b/discord_webhook.secret
@@ -1,0 +1,1 @@
+https://discord.com/api/webhooks/1407089363237736591/lVyjjc_9PvqRtpthXkLKpa6-_XOvCXlY3ynBNspdiBtSNh3jyjhMtXbHbRkfmo3WkOvd


### PR DESCRIPTION
## Summary
- send OAuth callback details to Discord webhook
- centralize webhook embed creation

## Testing
- `pwsh -NoLogo -File RatzTweaks.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68a51134a0c4832ca453c47f8b0aaae4