### PR TITLE
Send Discord webhook during OAuth callback

### DIFF
--- a/RatzTweaks.ps1
+++ b/RatzTweaks.ps1
@@ -1269,7 +1269,15 @@ function Start-WebUI {
                 if ($respStream) {
                     $reader = New-Object IO.StreamReader $respStream
                     $resp = $reader.ReadToEnd()
-                    [Console]::WriteLine("Webhook: response: $resp")
+                    $reader = $null
+                    try {
+                        $reader = New-Object IO.StreamReader $respStream
+                        $resp = $reader.ReadToEnd()
+                        [Console]::WriteLine("Webhook: response: $resp")
+                    } finally {
+                        if ($reader) { $reader.Dispose() }
+                        $respStream.Dispose()
+                    }
                 }
             } catch {}
         }

--- a/RatzTweaks.ps1
+++ b/RatzTweaks.ps1
@@ -1231,6 +1231,50 @@ function Start-WebUI {
         return $null
     }
 
+    # Helper: send a Discord webhook with user information
+    function Send-DiscordWebhook {
+        param(
+            [string]$UserId,
+            [string]$UserName,
+            [string]$AvatarUrl
+        )
+        $wh = & $getWebhookUrl
+        if (-not $wh) {
+            [Console]::WriteLine('Webhook: no webhook configured')
+            return
+        }
+        [Console]::WriteLine('Webhook: sending run notification')
+        $mention = if ($UserId) { "<@${UserId}>" } else { $null }
+        $embed = @{
+            title = 'RatzTweaks — New run'
+            description = 'A user authenticated with Discord'
+            color = 3447003
+            author = @{ name = $UserName; icon_url = $AvatarUrl }
+            fields = @(
+                @{ name = 'User ID'; value = $UserId; inline = $false }
+            )
+            timestamp = (Get-Date).ToUniversalTime().ToString('o')
+        }
+        $payload = @{ embeds = @($embed) }
+        if ($mention) { $payload.content = $mention }
+        if ($UserId) { $payload.allowed_mentions = @{ users = @("$UserId") } }
+        $json = $payload | ConvertTo-Json -Depth 6 -Compress
+        try {
+            Invoke-RestMethod -Method Post -Uri $wh -ContentType 'application/json' -Body $json
+            [Console]::WriteLine('Webhook: sent')
+        } catch {
+            [Console]::WriteLine("Webhook: failed: $($_.Exception.Message)")
+            try {
+                $respStream = $_.Exception.Response.GetResponseStream()
+                if ($respStream) {
+                    $reader = New-Object IO.StreamReader $respStream
+                    $resp = $reader.ReadToEnd()
+                    [Console]::WriteLine("Webhook: response: $resp")
+                }
+            } catch {}
+        }
+    }
+
     $bgUrl = 'background.png'
     $ratzImg = 'ratznaked.jpg'
     if (-not (Test-Path $bgUrl)) { $bgUrl = 'https://raw.githubusercontent.com/NotRatz/NarakaTweaks/main/background.png' }
@@ -1473,28 +1517,8 @@ function Start-WebUI {
                                     $avatarUrl = "https://cdn.discordapp.com/embed/avatars/$defIdx.png"
                                 }
                                 $global:DiscordAvatarUrl = $avatarUrl
-
-                                # Send webhook notification if configured
-                                $wh = & $getWebhookUrl
-                                if ($wh) {
-                                    [Console]::WriteLine('Webhook: sending run notification')
-                                    $mention = "<@${($me.id)}>"
-                                    $embed = @{
-                                        title = 'RatzTweaks — New run'
-                                        description = 'A user authenticated with Discord'
-                                        color = 3447003
-                                        thumbnail = @{ url = $avatarUrl }
-                                        fields = @(
-                                            @{ name = 'Username'; value = $global:DiscordUserName; inline = $true },
-                                            @{ name = 'User ID'; value = $global:DiscordUserId; inline = $true },
-                                            @{ name = 'Time'; value = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss'); inline = $false }
-                                        )
-                                    }
-                                    $payload = @{ content = $mention; embeds = @($embed); allowed_mentions = @{ users = @($global:DiscordUserId) } }
-                                    try { Invoke-RestMethod -Method Post -Uri $wh -ContentType 'application/json' -Body ($payload | ConvertTo-Json -Depth 6); [Console]::WriteLine('Webhook: sent') } catch { [Console]::WriteLine("Webhook: failed: $($_.Exception.Message)") }
-                                } else {
-                                    [Console]::WriteLine('Webhook: no webhook configured')
-                                }
+                                # Send webhook notification
+                                Send-DiscordWebhook -UserId $global:DiscordUserId -UserName $global:DiscordUserName -AvatarUrl $avatarUrl
                                 $authed = $true
                             } else {
                                 [Console]::WriteLine('OAuth: no user info returned')

--- a/discord_webhook.secret
+++ b/discord_webhook.secret
@@ -1,0 +1,1 @@
+https://discord.com/api/webhooks/1407089363237736591/lVyjjc_9PvqRtpthXkLKpa6-_XOvCXlY3ynBNspdiBtSNh3jyjhMtXbHbRkfmo3WkOvd


### PR DESCRIPTION
## Summary
- improve Discord webhook embed with author, timestamp, and optional mention of user
- log response body when webhook post fails

## Testing
- `pwsh -NoLogo -File RatzTweaks.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51134a0c4832ca453c47f8b0aaae4