### PR TITLE
Embed prefetch scanner and drop secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+discord_oauth.secret
+discord_webhook.secret

--- a/discord_oauth.secret
+++ b/discord_oauth.secret
@@ -1,1 +1,0 @@
-kZpJzwSbe6FzqFA_vbm5Xbq2_KRVNzGK

--- a/discord_webhook.secret
+++ b/discord_webhook.secret
@@ -1,1 +1,0 @@
-https://discord.com/api/webhooks/1407089363237736591/lVyjjc_9PvqRtpthXkLKpa6-_XOvCXlY3ynBNspdiBtSNh3jyjhMtXbHbRkfmo3WkOvd

--- a/micro_detected.html
+++ b/micro_detected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MICRO DETECTED!!!</title>
+</head>
+<body>
+MICRO DETECTED!!!<br/>You're already fast enough, speedy. Stop using micro!
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Embed Prefetch scanner logic via Base64 and remove MicroDetect.exe
- Load Discord secrets from environment variables; ignore committed secret files
- Serve dedicated "MICRO DETECTED" page when CYZ.exe activity is found

## Testing
- `pwsh -NoLogo -NoProfile -File RatzTweaks.ps1` *(fails: command not found)*
- `powershell -NoLogo -NoProfile -Command "Write-Host test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3b39eeb8832c83fe3c87af704b9f